### PR TITLE
Fix(auth): Redirect admin users to dashboard on login

### DIFF
--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -30,17 +30,21 @@ export function LoginForm() {
     setError(null)
 
     try {
-      const { user, error } = await signIn(email, password)
+      const { user, profile, error } = await signIn(email, password)
       
       if (error) {
         setError(error.message)
+        setIsLoading(false)
         return
       }
 
       if (user) {
-        // Redirect based on user role or intended destination
-        const intendedUrl = new URLSearchParams(window.location.search).get('redirect')
-        router.push(intendedUrl || '/account')
+        if (profile?.role === 'admin') {
+          router.push('/admin/dashboard')
+        } else {
+          const intendedUrl = new URLSearchParams(window.location.search).get('redirect')
+          router.push(intendedUrl || '/account')
+        }
       }
     } catch (err: any) {
       setError(err.message || 'An unexpected error occurred')

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -15,7 +15,7 @@ interface AuthContextType {
   
   // Auth methods
   signUp: (email: string, password: string, userData?: Partial<UserProfile>) => Promise<{ user: User | null; error: AuthError | null }>
-  signIn: (email: string, password: string) => Promise<{ user: User | null; session: Session | null; error: AuthError | null }>
+  signIn: (email: string, password: string) => Promise<{ user: User | null; session: Session | null; profile: UserProfile | null; error: AuthError | null }>
   signOut: () => Promise<{ error: AuthError | null }>
   resetPassword: (email: string) => Promise<{ error: AuthError | null }>
   updatePassword: (password: string) => Promise<{ error: AuthError | null }>
@@ -157,7 +157,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  const signIn = async (email: string, password: string) => {
+  const signIn = async (email: string, password: string): Promise<{ user: User | null; session: Session | null; profile: UserProfile | null; error: AuthError | null }> => {
     setLoading(true)
     setError(null)
     
@@ -168,10 +168,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       })
 
       if (error) throw error
-      return { user: data.user, session: data.session, error }
+      if (!data.user) throw new Error("Sign in completed but no user data returned.")
+
+      // Fetch user profile
+      const { data: profileData, error: profileError } = await supabase
+        .from('users')
+        .select('*')
+        .eq('id', data.user.id)
+        .single()
+
+      if (profileError) {
+        console.error('Error fetching user profile after signin:', profileError)
+        // still return user data, but profile will be null
+        return { user: data.user, session: data.session, profile: null, error: null }
+      }
+
+      setProfile(profileData) // update context state
+
+      // Return user, session, and the fetched profile
+      return { user: data.user, session: data.session, profile: profileData, error: null }
     } catch (error: any) {
       setError(error.message)
-      return { user: null, session: null, error }
+      return { user: null, session: null, profile: null, error }
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
Previously, all users were redirected to the `/account` page after logging in, regardless of their role. This meant that admin users had to manually navigate to the admin dashboard.

This change modifies the authentication flow to correctly handle admin users. The `signIn` function in `AuthContext` now fetches the user's profile immediately after a successful login. The `LoginForm` component then uses this profile information to check the user's role. If the user is an admin, they are redirected to `/admin/dashboard`; otherwise, they are redirected to the standard `/account` page.

This improves the user experience for admin users by taking them directly to the admin dashboard after they log in.