### PR TITLE
feat(admin): Implement user roles and permissions

### DIFF
--- a/app/admin/customers/actions.ts
+++ b/app/admin/customers/actions.ts
@@ -1,0 +1,20 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+import { revalidatePath } from "next/cache"
+
+export async function updateUserRole(userId: string, roleId: string) {
+  const supabase = await createClient()
+
+  const { error } = await supabase
+    .from("users")
+    .update({ role_id: roleId })
+    .eq("id", userId)
+
+  if (error) {
+    return { error: error.message }
+  }
+
+  revalidatePath("/admin/customers")
+  return { success: true }
+}

--- a/app/admin/customers/client.tsx
+++ b/app/admin/customers/client.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState, useMemo, useTransition } from "react"
+import { updateUserRole } from "./actions"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -27,11 +28,15 @@ interface Customer {
   orders?: { count: number }[]
 }
 
+import { Role } from "@/types/role"
+
 interface CustomersClientProps {
   customers: Customer[]
+  roles: Role[]
 }
 
-export default function CustomersClient({ customers }: CustomersClientProps) {
+export default function CustomersClient({ customers, roles }: CustomersClientProps) {
+  const [isPending, startTransition] = useTransition()
   const [searchTerm, setSearchTerm] = useState("")
   const [roleFilter, setRoleFilter] = useState<string>("all")
   const [orderFilter, setOrderFilter] = useState<string>("all")
@@ -209,9 +214,26 @@ export default function CustomersClient({ customers }: CustomersClientProps) {
                       {customer.phone || "Not provided"}
                     </TableCell>
                     <TableCell>
-                      <Badge variant={customer.role === 'admin' ? 'default' : 'secondary'}>
-                        {customer.role || 'customer'}
-                      </Badge>
+                      <Select
+                        defaultValue={customer.role_id || undefined}
+                        onValueChange={(roleId) => {
+                          startTransition(() => {
+                            updateUserRole(customer.id, roleId)
+                          })
+                        }}
+                        disabled={isPending}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select role" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {roles.map((role) => (
+                            <SelectItem key={role.id} value={role.id}>
+                              {role.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </TableCell>
                     <TableCell>
                       <div className="flex items-center space-x-1">

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -43,13 +43,28 @@ async function getCustomersForAdmin() {
   return customersWithOrders
 }
 
+import { Role } from "@/types/role"
+
+async function getRoles(): Promise<Role[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase.from("roles").select("*")
+  if (error) {
+    console.error("Error fetching roles:", error)
+    return []
+  }
+  return data
+}
+
 export default async function CustomersPage() {
-  const customers = await getCustomersForAdmin()
+  const [customers, roles] = await Promise.all([
+    getCustomersForAdmin(),
+    getRoles(),
+  ])
 
   return (
-    <AdminGuard>
+    <AdminGuard requiredPermissions={['manage-customers']}>
       <AdminLayout>
-        <CustomersClient customers={customers} />
+        <CustomersClient customers={customers} roles={roles} />
       </AdminLayout>
     </AdminGuard>
   )

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -274,7 +274,7 @@ async function DashboardContent() {
 
 export default function AdminDashboard() {
   return (
-    <AdminGuard>
+    <AdminGuard requiredPermissions={['view-dashboard']}>
       <AdminLayout>
         <DashboardContent />
       </AdminLayout>

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -49,8 +49,17 @@ async function getOrdersForAdmin() {
   return ordersWithDetails
 }
 
+import { AdminGuard } from '@/lib/auth/admin-guard'
+import { AdminLayout } from '@/components/admin/AdminLayout'
+
 export default async function AdminOrdersPage() {
   const orders = await getOrdersForAdmin()
 
-  return <OrdersClient orders={orders} />
+  return (
+    <AdminGuard requiredPermissions={['manage-orders']}>
+      <AdminLayout>
+        <OrdersClient orders={orders} />
+      </AdminLayout>
+    </AdminGuard>
+  )
 }

--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -35,11 +35,20 @@ async function getCategoriesForFilter() {
   return data || []
 }
 
+import { AdminGuard } from '@/lib/auth/admin-guard'
+import { AdminLayout } from '@/components/admin/AdminLayout'
+
 export default async function AdminProductsPage() {
   const [products, categories] = await Promise.all([
     getProductsForAdmin(),
     getCategoriesForFilter()
   ])
 
-  return <ProductsClient products={products} categories={categories} />
+  return (
+    <AdminGuard requiredPermissions={['manage-products']}>
+      <AdminLayout>
+        <ProductsClient products={products} categories={categories} />
+      </AdminLayout>
+    </AdminGuard>
+  )
 }

--- a/app/admin/reviews/page.tsx
+++ b/app/admin/reviews/page.tsx
@@ -1,0 +1,33 @@
+import { createClient } from "@/lib/supabase/server"
+import ReviewsClient from "./client"
+import { AdminGuard } from '@/lib/auth/admin-guard'
+import { AdminLayout } from '@/components/admin/AdminLayout'
+
+async function getReviews() {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("reviews")
+    .select(`
+      *,
+      product:products (name),
+      user:users (first_name, last_name)
+    `)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    console.error("Error fetching reviews:", error)
+    return []
+  }
+  return data
+}
+
+export default async function AdminReviewsPage() {
+  const reviews = await getReviews()
+  return (
+    <AdminGuard requiredPermissions={['manage-reviews']}>
+      <AdminLayout>
+        <ReviewsClient reviews={reviews} />
+      </AdminLayout>
+    </AdminGuard>
+  )
+}

--- a/app/admin/roles/actions.ts
+++ b/app/admin/roles/actions.ts
@@ -1,0 +1,91 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+import { RoleFormValues } from "@/components/role-form"
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+
+export async function createRole(values: RoleFormValues) {
+  const supabase = await createClient()
+
+  const { data: newRole, error: roleError } = await supabase
+    .from("roles")
+    .insert({ name: values.name })
+    .select("id")
+    .single()
+
+  if (roleError) {
+    return { error: roleError.message }
+  }
+
+  if (values.permission_ids.length > 0) {
+    const permissionsToInsert = values.permission_ids.map(permissionId => ({
+      role_id: newRole.id,
+      permission_id: permissionId,
+    }))
+    const { error: permissionsError } = await supabase
+      .from("role_has_permissions")
+      .insert(permissionsToInsert)
+    if (permissionsError) {
+      // Optionally, delete the role if permissions fail to insert
+      await supabase.from("roles").delete().eq("id", newRole.id)
+      return { error: `Failed to assign permissions: ${permissionsError.message}` }
+    }
+  }
+
+  revalidatePath("/admin/roles")
+  redirect("/admin/roles")
+}
+
+export async function updateRole(id: string, values: RoleFormValues) {
+  const supabase = await createClient()
+
+  const { error: roleError } = await supabase
+    .from("roles")
+    .update({ name: values.name })
+    .eq("id", id)
+
+  if (roleError) {
+    return { error: roleError.message }
+  }
+
+  // Delete existing permissions
+  const { error: deleteError } = await supabase
+    .from("role_has_permissions")
+    .delete()
+    .eq("role_id", id)
+  if (deleteError) {
+    return { error: `Failed to update permissions (delete step): ${deleteError.message}` }
+  }
+
+  // Insert new permissions
+  if (values.permission_ids.length > 0) {
+    const permissionsToInsert = values.permission_ids.map(permissionId => ({
+      role_id: id,
+      permission_id: permissionId,
+    }))
+    const { error: permissionsError } = await supabase
+      .from("role_has_permissions")
+      .insert(permissionsToInsert)
+    if (permissionsError) {
+      return { error: `Failed to update permissions (insert step): ${permissionsError.message}` }
+    }
+  }
+
+  revalidatePath("/admin/roles")
+  revalidatePath(`/admin/roles/${id}/edit`)
+  redirect("/admin/roles")
+}
+
+export async function deleteRole(id: string) {
+  const supabase = await createClient()
+
+  const { error } = await supabase.from("roles").delete().eq("id", id)
+
+  if (error) {
+    return { error: error.message }
+  }
+
+  revalidatePath("/admin/roles")
+  redirect("/admin/roles")
+}

--- a/app/admin/roles/client.tsx
+++ b/app/admin/roles/client.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table"
+import Link from "next/link"
+import { PlusCircle } from "lucide-react"
+import { Role } from "@/types/role"
+
+interface RolesClientProps {
+  roles: Role[]
+}
+
+export default function RolesClient({ roles }: RolesClientProps) {
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Roles</h1>
+        <Button asChild>
+          <Link href="/admin/roles/new">
+            <PlusCircle className="mr-2 h-4 w-4" />
+            Add New Role
+          </Link>
+        </Button>
+      </div>
+
+      <div className="border rounded-lg bg-background">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Permissions</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {roles.map(role => (
+              <TableRow key={role.id}>
+                <TableCell className="font-medium">{role.name}</TableCell>
+                <TableCell>
+                  {role.permissions?.map(p => p.name).join(', ')}
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button variant="ghost" size="sm" asChild>
+                    <Link href={`/admin/roles/${role.id}/edit`}>Edit</Link>
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {roles.length === 0 && (
+        <div className="text-center text-muted-foreground py-12">
+          No roles found.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/roles/new/client.tsx
+++ b/app/admin/roles/new/client.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { useState } from "react"
+import { RoleForm, RoleFormValues } from "@/components/role-form"
+import { createRole } from "../actions"
+import { Permission } from "@/types/role"
+
+export function NewRolePageClient({ permissions }: { permissions: Permission[] }) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const onSubmit = async (values: RoleFormValues) => {
+    setIsSubmitting(true)
+    setError(null)
+    const result = await createRole(values)
+    if (result?.error) {
+      setError(result.error)
+      setIsSubmitting(false)
+    }
+    // On success, the server action will redirect.
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Add New Role</h1>
+        <p className="text-muted-foreground">Fill out the form below to add a new role.</p>
+      </div>
+      {error && (
+        <div className="p-4 bg-destructive/10 text-destructive-foreground border border-destructive rounded-md">
+          <p><strong>Error:</strong> {error}</p>
+        </div>
+      )}
+      <RoleForm
+        permissions={permissions}
+        onSubmit={onSubmit}
+        isSubmitting={isSubmitting}
+      />
+    </div>
+  )
+}

--- a/app/admin/roles/new/page.tsx
+++ b/app/admin/roles/new/page.tsx
@@ -1,0 +1,18 @@
+import { NewRolePageClient } from "./client"
+import { createClient } from "@/lib/supabase/server"
+import { Permission } from "@/types/role"
+
+async function getPermissions(): Promise<Permission[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase.from("permissions").select("*").order("name")
+  if (error) {
+    console.error("Failed to fetch permissions:", error)
+    return []
+  }
+  return data
+}
+
+export default async function NewRolePage() {
+  const permissions = await getPermissions()
+  return <NewRolePageClient permissions={permissions} />
+}

--- a/app/admin/roles/page.tsx
+++ b/app/admin/roles/page.tsx
@@ -1,0 +1,30 @@
+import { createClient } from "@/lib/supabase/server"
+import RolesClient from "./client"
+
+async function getRoles() {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("roles")
+    .select("*, permissions(*)")
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    console.error("Error fetching roles:", error)
+    return []
+  }
+  return data
+}
+
+import { AdminGuard } from '@/lib/auth/admin-guard'
+import { AdminLayout } from '@/components/admin/AdminLayout'
+
+export default async function AdminRolesPage() {
+  const roles = await getRoles()
+  return (
+    <AdminGuard requiredPermissions={['manage-roles']}>
+      <AdminLayout>
+        <RolesClient roles={roles} />
+      </AdminLayout>
+    </AdminGuard>
+  )
+}

--- a/components/role-form.tsx
+++ b/components/role-form.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import * as React from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import * as z from "zod"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Role, Permission } from "@/types/role"
+
+const formSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 characters."),
+  permission_ids: z.array(z.string()).default([]),
+})
+
+export type RoleFormValues = z.infer<typeof formSchema>
+
+interface RoleFormProps {
+  role?: Role;
+  permissions: Permission[];
+  onSubmit: (values: RoleFormValues) => void;
+  isSubmitting: boolean;
+}
+
+export function RoleForm({ role, permissions, onSubmit, isSubmitting }: RoleFormProps) {
+  const form = useForm<RoleFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: role?.name || "",
+      permission_ids: role?.permissions?.map(p => p.id) || [],
+    },
+  })
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Role Name</FormLabel>
+              <FormControl>
+                <Input placeholder="e.g. Product Manager" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="permission_ids"
+          render={() => (
+            <FormItem>
+              <div className="mb-4">
+                <FormLabel className="text-base">Permissions</FormLabel>
+              </div>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                {permissions.map((permission) => (
+                  <FormField
+                    key={permission.id}
+                    control={form.control}
+                    name="permission_ids"
+                    render={({ field }) => {
+                      return (
+                        <FormItem
+                          key={permission.id}
+                          className="flex flex-row items-start space-x-3 space-y-0"
+                        >
+                          <FormControl>
+                            <Checkbox
+                              checked={field.value?.includes(permission.id)}
+                              onCheckedChange={(checked) => {
+                                return checked
+                                  ? field.onChange([...field.value, permission.id])
+                                  : field.onChange(
+                                      field.value?.filter(
+                                        (value) => value !== permission.id
+                                      )
+                                    )
+                              }}
+                            />
+                          </FormControl>
+                          <FormLabel className="font-normal">
+                            {permission.name}
+                          </FormLabel>
+                        </FormItem>
+                      )
+                    }}
+                  />
+                ))}
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={isSubmitting} size="lg" className="w-full">
+          {isSubmitting ? "Saving..." : (role ? "Save Changes" : "Create Role")}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/scripts/021_create_roles_and_permissions_tables.sql
+++ b/scripts/021_create_roles_and_permissions_tables.sql
@@ -1,0 +1,22 @@
+CREATE TABLE roles (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(255) UNIQUE NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE permissions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(255) UNIQUE NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE role_has_permissions (
+    role_id UUID REFERENCES roles(id) ON DELETE CASCADE,
+    permission_id UUID REFERENCES permissions(id) ON DELETE CASCADE,
+    PRIMARY KEY (role_id, permission_id)
+);
+
+ALTER TABLE users
+ADD COLUMN role_id UUID REFERENCES roles(id) ON DELETE SET NULL;

--- a/scripts/022_insert_default_permissions.sql
+++ b/scripts/022_insert_default_permissions.sql
@@ -1,0 +1,9 @@
+INSERT INTO permissions (name) VALUES
+('view-dashboard'),
+('manage-products'),
+('manage-orders'),
+('manage-customers'),
+('manage-roles'),
+('manage-reviews'),
+('manage-blog'),
+('manage-pages');

--- a/types/role.ts
+++ b/types/role.ts
@@ -1,0 +1,14 @@
+export interface Permission {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Role {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  permissions?: Permission[];
+}


### PR DESCRIPTION
This commit introduces a new role-based access control (RBAC) system to the admin panel.

-   **Roles & Permissions:** A new system for creating and managing roles with specific permissions has been added. This includes new database tables for `roles`, `permissions`, and `role_has_permissions`.
-   **Admin UI:** A new section has been added to the admin panel at `/admin/roles` for managing roles and their permissions.
-   **User Management:** The user management page at `/admin/customers` has been updated to allow admins to assign roles to users.
-   **Access Control:** The `AdminGuard` component has been updated to check for specific permissions, rather than just a static 'admin' role. This allows for more granular control over what users can access in the admin panel.
-   **Dashboard Analytics:** The main dashboard has been enhanced with a sales chart to visualize revenue over time.